### PR TITLE
Split CI workflow into lint and test jobs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# GeoGuessrEnv Copilot Instructions
+## Project snapshot
+- Core environment: `geoguess_env/geoguessr_env.py` couples `GeoGuessrConfig`, `AssetManager`, and `ActionParser` to drive Gymnasium episodes returning `{"image": np.uint8[H, W, 3]}` observations.
+- `AssetManager.prepare_graph(...)` hydrates cached panoramas, retries downloads, and blocklists failures in `cache/metadata/failed_panoramas.json`; repeated calls round lat/lon to six decimals when resolving panoramas.
+- Configuration flows through `GeoGuessrConfig.from_dict`, which normalizes `cache_root`, validates coordinates, and nests provider/render/navigation configs—keep new settings inside those dataclasses.
+- Navigation budget is two-tiered: env `max_steps` (default 40) and agent `AgentConfig.max_nav_steps`; always furnish a fallback answer when either limit is hit.
+## Agent patterns
+- The only accepted action schema is `{"op": "click"|"answer", "value": [...]}`; `ActionParser` clamps coordinates and falls back to center-click, so match that shape when producing actions or tests.
+- Base agent contracts live in `agents/base.py`; extend `AgentConfig` instead of sprinkling kwargs, and honour cached response helpers in `agents/utils.py` (`cache_get`, `cache_put`, `compute_prompt_fingerprint`).
+- `agents/openai_agent.py` funnels OpenAI tool calls through `VLMBroker`; snap clicks to provided `info["links"]` (see `_snap_to_nearest_link`) and preserve the history window for context-aware prompts.
+- Offline baseline behaviour is in `geoguess_env/baseline_agent.py`; reuse its link sweep and continent heuristics when you need deterministic fallbacks.
+- Persist agent artifacts under `cache/agent_<name>/` and reuse JPEG/base64 helpers from `agents/utils.py` rather than re-encoding manually.
+## Workflow essentials
+- Manage dependencies with uv only: `uv pip install -e .`, then format/lint/typecheck via `uv run ruff format .`, `uv run ruff check . --fix`, and `uv run ty check .`.
+- Quick demos: `uv run python geoguessr_env_demo.py` for manual play, or `uv run python scripts/run_openai_agent.py --model gpt-4o --max_nav_steps 10 --render` (supply 6-decimal `--input_lat/--input_lon`).
+- Baseline evaluation entry point: `uv run python -m geoguess_env.run_baseline --geofence geofences/seattle_15km.json --episodes 2 --cache ./cache --out results.csv`.
+## Data & caching
+- Cache layout is fixed: `cache/images/` for JPEGs, `cache/metadata/` for JSONL graphs, `cache/replays/` for episode logs; preserve it when adding new assets.
+- `AssetManager` prunes invalid links and skips blocklisted panoramas—tests in `tests/test_env_retry_logic.py` depend on that retry + blocklist handshake.
+- When fetching new data, call `AssetManager.preload_assets` or `prepare_graph`; direct file writes risk bypassing hash validation.
+## Testing cues
+- Unit tests mock asset loading heavily (see `tests/test_env_retry_logic.py` and `tests/test_integration.py`); prefer patching `prepare_graph` or `resolve_nearest_panorama` instead of touching disk.
+- `tests/test_openai_agent_tools.py` asserts click snapping and value clamping; preserve `{"op": ..., "value": [...]}` outputs when refactoring the agent.
+- Geometry utilities (`geoguess_env/geometry_utils.py`) back both reward and distance reporting—update corresponding tests if you touch haversine math or scoring.

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,38 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  lint-typecheck:
+    environment: pytest-env
+    runs-on: ubuntu-latest
+    env:
+      GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.12"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+      with:
+        version: "latest"
+    - name: Install dependencies
+      run: |
+        uv sync
+    - name: Lint with ruff
+      run: |
+        uv run ruff check .
+    - name: Check formatting with ruff
+      run: |
+        uv run ruff format --check .
+    - name: Type check with ty
+      run: |
+        uv run ty check .
+
+  tests:
+    needs: lint-typecheck
     environment: pytest-env
     runs-on: ubuntu-latest
     env:
@@ -34,15 +65,6 @@ jobs:
     - name: Install dependencies
       run: |
         uv sync
-    - name: Lint with ruff
-      run: |
-        uv run ruff check .
-    - name: Check formatting with ruff
-      run: |
-        uv run ruff format --check .
-    - name: Type check with ty
-      run: |
-        uv run ty check .
     - name: Test with pytest
       run: |
         uv run pytest

--- a/tests/test_openai_agent_tools.py
+++ b/tests/test_openai_agent_tools.py
@@ -1,7 +1,4 @@
-import os
-
 import numpy as np
-import pytest
 
 from agents.base import AgentConfig
 from agents.openai_agent import OpenAIVisionAgent
@@ -34,9 +31,6 @@ def _info_with_links(steps: int = 0):
     }
 
 
-@pytest.mark.skipif(
-    "OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set"
-)
 def test_act_click_snaps_to_nearest_link():
     cfg = AgentConfig(cache_dir=None)
     stub = {"op": "click", "click": {"x": 960, "y": 240}}
@@ -51,9 +45,6 @@ def test_act_click_snaps_to_nearest_link():
     assert action["value"] == [942, 256]
 
 
-@pytest.mark.skipif(
-    "OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set"
-)
 def test_act_answer_is_clamped():
     cfg = AgentConfig(cache_dir=None)
     stub = {"op": "answer", "answer": {"lat": 123.4, "lon": -200.0}}
@@ -68,9 +59,6 @@ def test_act_answer_is_clamped():
     assert action["value"] == [90.0, -180.0]
 
 
-@pytest.mark.skipif(
-    "OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set"
-)
 def test_fallback_click_then_answer():
     cfg = AgentConfig(cache_dir=None)
 


### PR DESCRIPTION
- run Ruff formatting, linting, and ty check in a dedicated job on Python 3.12
- execute pytest in a separate matrixed job that depends on lint/typecheck results